### PR TITLE
Fix README.md kit file name s/macaroni.yml/test.yml/

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ target:
 The command:
 
 ```bash
-$> mark-devkit doit --specfile myspec.yml --kitfile merge.kit.d/macaroni.yml --show-values
+$> mark-devkit doit --specfile myspec.yml --kitfile merge.kit.d/test.yml --show-values
 😷 Loading specfile contrib/autogen/noop_example.yml
 🏰 Work directory:	workdir
 🚀 Target Kit:		mark-kit


### PR DESCRIPTION
In `doit` command' example kit's file name is `merge.kit.d/test.yml`,  but in command line -- `merge.kit.d/macaroni.yml`.

Fix to use the same (`test.yml`) in command line too.